### PR TITLE
feat: add rules S004, S005, S006

### DIFF
--- a/src/rules/S004-file-size.ts
+++ b/src/rules/S004-file-size.ts
@@ -1,0 +1,28 @@
+import { Rule, LintResult, ParsedSpecFile } from '../types.js';
+
+const WARN_THRESHOLD = 30 * 1024;
+const ERROR_THRESHOLD = 50 * 1024;
+
+export const fileSizeRule: Rule = {
+  id: 'S004',
+  name: 'file-size',
+  severity: 'warning',
+  description: 'Spec files over 30kb warn (context bloat), over 50kb error',
+  check(file: ParsedSpecFile): LintResult[] {
+    if (file.sizeBytes > ERROR_THRESHOLD) {
+      return [{
+        ruleId: 'S004',
+        severity: 'error',
+        message: `File is ${Math.round(file.sizeBytes / 1024)}kb — exceeds 50kb limit. Split into smaller files to avoid context bloat.`,
+      }];
+    }
+    if (file.sizeBytes > WARN_THRESHOLD) {
+      return [{
+        ruleId: 'S004',
+        severity: 'warning',
+        message: `File is ${Math.round(file.sizeBytes / 1024)}kb — over 30kb warning threshold. Consider splitting.`,
+      }];
+    }
+    return [];
+  },
+};

--- a/src/rules/S005-no-wildcard-permissions.ts
+++ b/src/rules/S005-no-wildcard-permissions.ts
@@ -1,0 +1,32 @@
+import { Rule, LintResult, ParsedSpecFile } from '../types.js';
+
+const WILDCARD_PATTERNS: { pattern: RegExp; label: string }[] = [
+  { pattern: /\w+\(\*:\*\)/, label: 'Wildcard tool permission (Tool(*:*))' },
+  { pattern: /"allow"\s*:\s*\[\s*"\*"\s*\]/, label: 'Wildcard allow list ("allow": ["*"])' },
+  { pattern: /permissions\s*:\s*"\*"/, label: 'Wildcard permissions string' },
+];
+
+export const noWildcardPermissionsRule: Rule = {
+  id: 'S005',
+  name: 'no-wildcard-permissions',
+  severity: 'error',
+  description: 'Tool permissions must not use wildcards — be explicit about allowed tools',
+  check(file: ParsedSpecFile): LintResult[] {
+    const results: LintResult[] = [];
+    const lines = file.raw.split('\n');
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      for (const { pattern, label } of WILDCARD_PATTERNS) {
+        if (pattern.test(line)) {
+          results.push({
+            ruleId: 'S005',
+            severity: 'error',
+            message: `${label} — use explicit tool names instead of wildcards.`,
+            line: i + 1,
+          });
+        }
+      }
+    }
+    return results;
+  },
+};

--- a/src/rules/S006-no-duplicate-headers.ts
+++ b/src/rules/S006-no-duplicate-headers.ts
@@ -1,0 +1,26 @@
+import { Rule, LintResult, ParsedSpecFile } from '../types.js';
+
+export const noDuplicateHeadersRule: Rule = {
+  id: 'S006',
+  name: 'no-duplicate-headers',
+  severity: 'warning',
+  description: 'Duplicate section headings at the same level cause confusion',
+  check(file: ParsedSpecFile): LintResult[] {
+    const results: LintResult[] = [];
+    const seen = new Map<string, number>();
+    for (const section of file.sections) {
+      const key = `${section.level}:${section.heading.toLowerCase()}`;
+      if (seen.has(key)) {
+        results.push({
+          ruleId: 'S006',
+          severity: 'warning',
+          message: `Duplicate heading "${section.heading}" (level ${section.level}) — first seen on line ${seen.get(key)}.`,
+          line: section.line,
+        });
+      } else {
+        seen.set(key, section.line);
+      }
+    }
+    return results;
+  },
+};

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,8 +1,14 @@
 import { Rule } from '../types.js';
 import { requiredSectionsRule } from './S001-required-sections.js';
 import { noSecretsRule } from './S003-no-secrets.js';
+import { fileSizeRule } from './S004-file-size.js';
+import { noWildcardPermissionsRule } from './S005-no-wildcard-permissions.js';
+import { noDuplicateHeadersRule } from './S006-no-duplicate-headers.js';
 
 export const allRules: Rule[] = [
   requiredSectionsRule,
   noSecretsRule,
+  fileSizeRule,
+  noWildcardPermissionsRule,
+  noDuplicateHeadersRule,
 ];

--- a/tests/rules/S004.test.ts
+++ b/tests/rules/S004.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { fileSizeRule } from '../../src/rules/S004-file-size.js';
+import { parseSpecFile } from '../../src/parser.js';
+
+describe('S004 file-size', () => {
+  const check = (content: string) => {
+    const file = parseSpecFile('/test.md', content);
+    return fileSizeRule.check(file);
+  };
+
+  it('passes a small file', () => {
+    expect(check('Small file content')).toHaveLength(0);
+  });
+
+  it('passes a file just under 30kb', () => {
+    const content = 'x'.repeat(29 * 1024);
+    expect(check(content)).toHaveLength(0);
+  });
+
+  it('warns for a file over 30kb', () => {
+    const content = 'x'.repeat(31 * 1024);
+    const results = check(content);
+    expect(results).toHaveLength(1);
+    expect(results[0].severity).toBe('warning');
+    expect(results[0].ruleId).toBe('S004');
+  });
+
+  it('errors for a file over 50kb', () => {
+    const content = 'x'.repeat(51 * 1024);
+    const results = check(content);
+    expect(results).toHaveLength(1);
+    expect(results[0].severity).toBe('error');
+  });
+
+  it('errors at exactly the 50kb boundary', () => {
+    const content = 'x'.repeat(50 * 1024 + 1);
+    const results = check(content);
+    expect(results).toHaveLength(1);
+    expect(results[0].severity).toBe('error');
+  });
+
+  it('passes an empty file', () => {
+    expect(check('')).toHaveLength(0);
+  });
+
+  it('has correct rule metadata', () => {
+    expect(fileSizeRule.id).toBe('S004');
+    expect(fileSizeRule.name).toBe('file-size');
+  });
+});

--- a/tests/rules/S005.test.ts
+++ b/tests/rules/S005.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { noWildcardPermissionsRule } from '../../src/rules/S005-no-wildcard-permissions.js';
+import { parseSpecFile } from '../../src/parser.js';
+
+describe('S005 no-wildcard-permissions', () => {
+  const check = (content: string) => {
+    const file = parseSpecFile('/test.md', content);
+    return noWildcardPermissionsRule.check(file);
+  };
+
+  it('passes a file with no permission blocks', () => {
+    expect(check('## Overview\n\nJust a normal spec.')).toHaveLength(0);
+  });
+
+  it('passes specific tool permissions', () => {
+    const content = '## Permissions\n\nBash(git:*)\nRead(src/*)';
+    expect(check(content)).toHaveLength(0);
+  });
+
+  it('passes a file with no wildcards', () => {
+    const content = '## Config\n\nallow: ["Read", "Write"]';
+    expect(check(content)).toHaveLength(0);
+  });
+
+  it('catches Bash(*:*) wildcard', () => {
+    const content = '## Permissions\n\nBash(*:*)';
+    const results = check(content);
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results[0].severity).toBe('error');
+  });
+
+  it('catches "allow": ["*"] in JSON-like blocks', () => {
+    const content = '## Config\n\n"allow": ["*"]';
+    const results = check(content);
+    expect(results.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('catches permissions: "*"', () => {
+    const content = '## Tools\n\npermissions: "*"';
+    const results = check(content);
+    expect(results.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('reports the correct line number', () => {
+    const content = 'Line 1\nLine 2\nBash(*:*)\nLine 4';
+    const results = check(content);
+    expect(results[0].line).toBe(3);
+  });
+
+  it('catches multiple wildcards', () => {
+    const content = 'Bash(*:*)\n\n"allow": ["*"]';
+    const results = check(content);
+    expect(results.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('has correct rule metadata', () => {
+    expect(noWildcardPermissionsRule.id).toBe('S005');
+    expect(noWildcardPermissionsRule.severity).toBe('error');
+  });
+});

--- a/tests/rules/S006.test.ts
+++ b/tests/rules/S006.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { noDuplicateHeadersRule } from '../../src/rules/S006-no-duplicate-headers.js';
+import { parseSpecFile } from '../../src/parser.js';
+
+describe('S006 no-duplicate-headers', () => {
+  const check = (content: string) => {
+    const file = parseSpecFile('/test.md', content);
+    return noDuplicateHeadersRule.check(file);
+  };
+
+  it('passes a file with unique headings', () => {
+    const content = '## Overview\n\n## Constraints\n\n## Criteria';
+    expect(check(content)).toHaveLength(0);
+  });
+
+  it('passes an empty file', () => {
+    expect(check('')).toHaveLength(0);
+  });
+
+  it('passes headings at different levels with same text', () => {
+    const content = '# Overview\n\n## Overview';
+    expect(check(content)).toHaveLength(0);
+  });
+
+  it('catches duplicate ## headings', () => {
+    const content = '## Overview\n\nFirst\n\n## Overview\n\nSecond';
+    const results = check(content);
+    expect(results).toHaveLength(1);
+    expect(results[0].severity).toBe('warning');
+  });
+
+  it('reports the line of the duplicate, not the original', () => {
+    const content = '## Overview\n\nFirst\n\n## Overview\n\nSecond';
+    const results = check(content);
+    expect(results[0].line).toBe(5);
+  });
+
+  it('catches multiple sets of duplicates', () => {
+    const content = '## A\n\n## B\n\n## A\n\n## B';
+    const results = check(content);
+    expect(results).toHaveLength(2);
+  });
+
+  it('is case-insensitive', () => {
+    const content = '## Overview\n\n## overview';
+    const results = check(content);
+    expect(results).toHaveLength(1);
+  });
+
+  it('has correct rule metadata', () => {
+    expect(noDuplicateHeadersRule.id).toBe('S006');
+    expect(noDuplicateHeadersRule.severity).toBe('warning');
+  });
+});


### PR DESCRIPTION
## Summary
- **S004 file-size**: warns on files >30kb, errors on files >50kb to prevent context bloat
- **S005 no-wildcard-permissions**: detects `Bash(*:*)`, `"allow": ["*"]`, and `permissions: "*"` patterns
- **S006 no-duplicate-headers**: catches duplicate section headings at the same level (case-insensitive)
- Registers all 5 rules (S001, S003, S004, S005, S006) in `rules/index.ts`

## Test coverage
- S004: 7 tests (3 pass, 3 fail, 1 metadata)
- S005: 9 tests (3 pass, 5 fail, 1 metadata)
- S006: 8 tests (3 pass, 4 fail, 1 metadata)
- Full suite: 55 tests, all passing

## Test plan
- [x] All 55 tests pass (`npx vitest run`)
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] TDD workflow followed: tests written first, verified red, then green
- [ ] CI confirms tests pass on macOS, Linux, Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)